### PR TITLE
Fixes "Quit" function and adds shortcuts for linux

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -13,9 +13,16 @@ const template = [
   {
     label: 'Application',
     submenu: [
-      { label: 'About Application', selector: 'orderFrontStandardAboutPanel:' },
+      {
+        label: 'About Application',
+        selector: 'orderFrontStandardAboutPanel:' //FIXME only works on OSX
+      },
       { type: 'separator' },
-      { label: 'Quit', accelerator: 'Command+Q', selector: 'terminate:'}
+      {
+        label: 'Quit',
+        accelerator: 'CmdOrCtrl+Q',
+        click: function() {remote.app.exit(0);}
+      }
     ]
   }, 
   {
@@ -35,13 +42,13 @@ const template = [
     submenu: [
       {
         label: 'Reload',
-        accelerator: 'Command+R',
+        accelerator: 'CmdOrCtrl+R',
         click: function() { remote.getCurrentWindow().reload(); }
       }, 
       { type: 'separator' },
       {
         label: 'Toggle DevTools',
-        accelerator: 'Alt+Command+I',
+        accelerator: 'Alt+CmdOrCtrl+I',
         click: function() { remote.getCurrentWindow().toggleDevTools(); }
       }
     ]


### PR DESCRIPTION
It seems that most selectors only work on OSX, don't even know how to replace the "About Application".

Also got some eslint errors on lines 24, 46 and 52 but - since I didn't touch the last two - decided to follow their standard. Should I follow the rules on the eslint? (violating rule below)

```
    "semi": [
        "error",
        "never"
    ]
```
